### PR TITLE
Add person suggestion search and selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,12 +38,39 @@
         .mapping-select {
             width: 100%;
         }
-        .org-suggestion {
+        .suggestion-block {
             border: 1px solid #ddd;
             padding: 10px;
             margin-top: 5px;
         }
+        .org-selection-help {
+            margin-top: 6px;
+            font-size: 0.9em;
+            color: #555;
+            line-height: 1.4;
+        }
         /* Tab styles */
+        .section-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+        }
+        .toggle-btn {
+            background-color: #007bff;
+            color: #fff;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            padding: 6px 12px;
+        }
+        .toggle-btn:hover {
+            background-color: #0056b3;
+        }
+        .toggle-btn:focus {
+            outline: 2px solid #0056b3;
+            outline-offset: 2px;
+        }
         .tab {
             overflow: hidden;
             border: 1px solid #ccc;
@@ -88,18 +115,23 @@
 </section>
 
 <section id="fields-section" style="display:none;">
-    <h2>Organization &amp; Person Fields</h2>
-    <!-- Tab buttons -->
-    <div class="tab">
-        <button class="tablinks" id="orgTabBtn" onclick="openTab(event, 'OrgFieldsTab')">Organization Fields</button>
-        <button class="tablinks" id="personTabBtn" onclick="openTab(event, 'PersonFieldsTab')">Person Fields</button>
+    <div class="section-header">
+        <h2>Organization &amp; Person Fields</h2>
+        <button type="button" id="toggleFieldsBtn" class="toggle-btn" aria-expanded="true" aria-controls="fieldsContent">Hide Fields</button>
     </div>
-    <!-- Tab content -->
-    <div id="OrgFieldsTab" class="tabcontent">
-        <table id="orgFieldsTable"></table>
-    </div>
-    <div id="PersonFieldsTab" class="tabcontent">
-        <table id="personFieldsTable"></table>
+    <div id="fieldsContent">
+        <!-- Tab buttons -->
+        <div class="tab">
+            <button class="tablinks" id="orgTabBtn" onclick="openTab(event, 'OrgFieldsTab')">Organization Fields</button>
+            <button class="tablinks" id="personTabBtn" onclick="openTab(event, 'PersonFieldsTab')">Person Fields</button>
+        </div>
+        <!-- Tab content -->
+        <div id="OrgFieldsTab" class="tabcontent">
+            <table id="orgFieldsTable"></table>
+        </div>
+        <div id="PersonFieldsTab" class="tabcontent">
+            <table id="personFieldsTable"></table>
+        </div>
     </div>
 </section>
 
@@ -110,9 +142,12 @@
 </section>
 
 <section id="search-section" style="margin-top:20px; display:none;">
-    <h2>Organization Suggestions</h2>
-    <button id="searchOrgBtn">Search Existing Organizations</button>
-    <div id="orgSuggestionSection"></div>
+    <h2>Organization &amp; Person Suggestions</h2>
+    <button id="searchRecordsBtn">Search Existing Records</button>
+    <div id="suggestionSection">
+        <div id="orgSuggestionSection"></div>
+        <div id="personSuggestionSection"></div>
+    </div>
 </section>
 
 <section id="push-section" style="margin-top:20px; display:none;">
@@ -127,40 +162,145 @@ let personFields = [];
 let csvData = [];
 let columnMappings = {}; // mapping of CSV column to field/person/organization
 let organizationSuggestions = {}; // suggestions for each organization name
+let personSuggestions = {}; // suggestions for each person name
+let isFieldsCollapsed = false;
 
-function fetchFields() {
+function normalizeNameKey(value) {
+    return value ? value.trim().toLowerCase() : '';
+}
+
+function populateMappingOptions(select) {
+    select.innerHTML = '';
+    const defaultOpt = document.createElement('option');
+    defaultOpt.value = '';
+    defaultOpt.textContent = '-- Ignore --';
+    select.appendChild(defaultOpt);
+
+    const personOpt = document.createElement('option');
+    personOpt.value = 'person_name';
+    personOpt.textContent = 'Person Name';
+    select.appendChild(personOpt);
+
+    const orgOpt = document.createElement('option');
+    orgOpt.value = 'organization_name';
+    orgOpt.textContent = 'Organization Name';
+    select.appendChild(orgOpt);
+
+    const noteOpt = document.createElement('option');
+    noteOpt.value = 'note';
+    noteOpt.textContent = 'Note';
+    select.appendChild(noteOpt);
+
+    if (orgFields.length > 0) {
+        const optgroupOrg = document.createElement('optgroup');
+        optgroupOrg.label = 'Organization Fields';
+        orgFields.forEach(f => {
+            const opt = document.createElement('option');
+            opt.value = `orgField:${f.key}`;
+            opt.textContent = f.name;
+            optgroupOrg.appendChild(opt);
+        });
+        select.appendChild(optgroupOrg);
+    }
+
+    if (personFields.length > 0) {
+        const optgroupPerson = document.createElement('optgroup');
+        optgroupPerson.label = 'Person Fields';
+        personFields.forEach(f => {
+            const opt = document.createElement('option');
+            opt.value = `personField:${f.key}`;
+            opt.textContent = f.name;
+            optgroupPerson.appendChild(opt);
+        });
+        select.appendChild(optgroupPerson);
+    }
+
+    const addNewOpt = document.createElement('option');
+    addNewOpt.value = 'add_new_field';
+    addNewOpt.textContent = 'Add new field';
+    select.appendChild(addNewOpt);
+}
+
+function refreshMappingSelectOptions() {
+    const selects = document.querySelectorAll('.mapping-select');
+    selects.forEach(select => {
+        const column = select.dataset.column;
+        const currentMapping = columnMappings[column] || '';
+        populateMappingOptions(select);
+        if (currentMapping && Array.from(select.options).some(opt => opt.value === currentMapping)) {
+            select.value = currentMapping;
+        } else {
+            select.value = '';
+            columnMappings[column] = '';
+        }
+        select.dataset.previousValue = select.value;
+    });
+}
+
+function toggleFieldsSection() {
+    const fieldsContent = document.getElementById('fieldsContent');
+    const toggleBtn = document.getElementById('toggleFieldsBtn');
+    isFieldsCollapsed = !isFieldsCollapsed;
+    if (isFieldsCollapsed) {
+        fieldsContent.style.display = 'none';
+        toggleBtn.textContent = 'Show Fields';
+        toggleBtn.setAttribute('aria-expanded', 'false');
+    } else {
+        fieldsContent.style.display = 'block';
+        toggleBtn.textContent = 'Hide Fields';
+        toggleBtn.setAttribute('aria-expanded', 'true');
+    }
+}
+
+async function fetchFields() {
     const subdomain = document.getElementById('subdomain').value.trim();
     const token = document.getElementById('apitoken').value.trim();
     const statusEl = document.getElementById('connectionStatus');
     if (!subdomain || !token) {
         statusEl.textContent = 'Please enter both subdomain and token.';
-        return;
+        return false;
     }
     statusEl.textContent = '';
     // Fetch organization and person fields concurrently
     const orgUrl = `https://${subdomain}.pipedrive.com/api/v1/organizationFields?api_token=${token}`;
     const personUrl = `https://${subdomain}.pipedrive.com/api/v1/personFields?api_token=${token}`;
-    Promise.all([
-        fetch(orgUrl).then(res => res.json()),
-        fetch(personUrl).then(res => res.json())
-    ]).then(([orgRes, personRes]) => {
+    try {
+        const [orgRes, personRes] = await Promise.all([
+            fetch(orgUrl).then(res => res.json()),
+            fetch(personUrl).then(res => res.json())
+        ]);
         if (orgRes.success && personRes.success) {
             orgFields = orgRes.data;
             personFields = personRes.data;
             displayFields();
+            refreshMappingSelectOptions();
+            return true;
         } else {
             statusEl.textContent = 'Error fetching fields. Please check your credentials and subdomain.';
+            return false;
         }
-    }).catch(err => {
+    } catch (err) {
         console.error(err);
         statusEl.textContent = 'Network error fetching fields.';
-    });
+        return false;
+    }
 }
 
 function displayFields() {
     const section = document.getElementById('fields-section');
+    const fieldsContent = document.getElementById('fieldsContent');
+    const toggleBtn = document.getElementById('toggleFieldsBtn');
     // Show fields section
     section.style.display = 'block';
+    if (isFieldsCollapsed) {
+        fieldsContent.style.display = 'none';
+        toggleBtn.textContent = 'Show Fields';
+        toggleBtn.setAttribute('aria-expanded', 'false');
+    } else {
+        fieldsContent.style.display = 'block';
+        toggleBtn.textContent = 'Hide Fields';
+        toggleBtn.setAttribute('aria-expanded', 'true');
+    }
     // Prepare organization and person tables
     const orgTable = document.getElementById('orgFieldsTable');
     const personTable = document.getElementById('personFieldsTable');
@@ -218,6 +358,7 @@ function parseCSV(file) {
 function displayMappingOptions(columns) {
     const mappingDiv = document.getElementById('csvMappingSection');
     mappingDiv.innerHTML = '';
+    columnMappings = {};
     const table = document.createElement('table');
     const headerRow = document.createElement('tr');
     headerRow.innerHTML = '<th>CSV Column</th><th>Map To</th>';
@@ -229,50 +370,16 @@ function displayMappingOptions(columns) {
         const mapCell = document.createElement('td');
         const select = document.createElement('select');
         select.className = 'mapping-select';
-        // default option
-        const defaultOpt = document.createElement('option');
-        defaultOpt.value = '';
-        defaultOpt.textContent = '-- Ignore --';
-        select.appendChild(defaultOpt);
-        // Person/Organization/Note options
-        const personOpt = document.createElement('option');
-        personOpt.value = 'person_name';
-        personOpt.textContent = 'Person Name';
-        select.appendChild(personOpt);
-        const orgOpt = document.createElement('option');
-        orgOpt.value = 'organization_name';
-        orgOpt.textContent = 'Organization Name';
-        select.appendChild(orgOpt);
-        const noteOpt = document.createElement('option');
-        noteOpt.value = 'note';
-        noteOpt.textContent = 'Note';
-        select.appendChild(noteOpt);
-        // Custom fields options
-        if (orgFields.length > 0) {
-            const optgroupOrg = document.createElement('optgroup');
-            optgroupOrg.label = 'Organization Fields';
-            orgFields.forEach(f => {
-                const opt = document.createElement('option');
-                opt.value = `orgField:${f.key}`;
-                opt.textContent = f.name;
-                optgroupOrg.appendChild(opt);
-            });
-            select.appendChild(optgroupOrg);
-        }
-        if (personFields.length > 0) {
-            const optgroupPerson = document.createElement('optgroup');
-            optgroupPerson.label = 'Person Fields';
-            personFields.forEach(f => {
-                const opt = document.createElement('option');
-                opt.value = `personField:${f.key}`;
-                opt.textContent = f.name;
-                optgroupPerson.appendChild(opt);
-            });
-            select.appendChild(optgroupPerson);
-        }
-        select.onchange = function() {
+        select.dataset.column = col;
+        populateMappingOptions(select);
+        select.dataset.previousValue = select.value;
+        select.addEventListener('change', async function() {
+            if (this.value === 'add_new_field') {
+                await handleAddNewField(this, col);
+            }
             columnMappings[col] = this.value;
-        };
+            this.dataset.previousValue = this.value;
+        });
         mapCell.appendChild(select);
         row.appendChild(colCell);
         row.appendChild(mapCell);
@@ -284,52 +391,176 @@ function displayMappingOptions(columns) {
     document.getElementById('push-section').style.display = 'block';
 }
 
-async function searchExistingOrganizations() {
+async function searchExistingRecords() {
     const subdomain = document.getElementById('subdomain').value.trim();
     const token = document.getElementById('apitoken').value.trim();
-    const orgNameCol = Object.keys(columnMappings).find(col => columnMappings[col] === 'organization_name');
-    if (!orgNameCol) {
-        alert('Please map a column to "Organization Name" before searching.');
+    if (!subdomain || !token) {
+        alert('Please enter both subdomain and token before searching.');
         return;
     }
-    const uniqueNames = [...new Set(csvData.map(row => row[orgNameCol]).filter(name => name))];
+    const orgNameCol = Object.keys(columnMappings).find(col => columnMappings[col] === 'organization_name');
+    const personNameCol = Object.keys(columnMappings).find(col => columnMappings[col] === 'person_name');
+    if (!orgNameCol && !personNameCol) {
+        alert('Please map a column to "Organization Name" or "Person Name" before searching.');
+        return;
+    }
     organizationSuggestions = {};
+    personSuggestions = {};
     const suggestionContainer = document.getElementById('orgSuggestionSection');
+    const personContainer = document.getElementById('personSuggestionSection');
     suggestionContainer.innerHTML = '';
-    for (const name of uniqueNames) {
-        try {
-            const url = `https://${subdomain}.pipedrive.com/api/v1/organizations/search?term=${encodeURIComponent(name)}&fields=name&limit=5&api_token=${token}`;
-            const res = await fetch(url);
-            const data = await res.json();
-            let suggestions = [];
-            if (data.success && data.data && data.data.items) {
-                suggestions = data.data.items.map(item => item.item);
+    personContainer.innerHTML = '';
+
+    if (orgNameCol) {
+        const uniqueOrgNames = new Map();
+        csvData.forEach(row => {
+            const raw = row[orgNameCol];
+            const key = normalizeNameKey(raw);
+            if (!key) return;
+            if (!uniqueOrgNames.has(key)) {
+                uniqueOrgNames.set(key, raw.trim());
             }
-            organizationSuggestions[name] = suggestions;
-            // Render suggestion block
-            const div = document.createElement('div');
-            div.className = 'org-suggestion';
-            const title = document.createElement('strong');
-            title.textContent = `Suggestions for "${name}":`;
-            div.appendChild(title);
-            const select = document.createElement('select');
-            select.dataset.name = name;
-            // first option for new organization
-            const newOpt = document.createElement('option');
-            newOpt.value = 'new';
-            newOpt.textContent = '-- Create New --';
-            select.appendChild(newOpt);
-            suggestions.forEach(item => {
-                const opt = document.createElement('option');
-                opt.value = item.id;
-                opt.textContent = `${item.name} (ID: ${item.id})`;
-                select.appendChild(opt);
-            });
-            div.appendChild(document.createElement('br'));
-            div.appendChild(select);
-            suggestionContainer.appendChild(div);
-        } catch (err) {
-            console.error('Error fetching suggestions', err);
+        });
+        if (uniqueOrgNames.size > 0) {
+            const heading = document.createElement('h3');
+            heading.textContent = 'Organization Suggestions';
+            suggestionContainer.appendChild(heading);
+        }
+        for (const [nameKey, name] of uniqueOrgNames.entries()) {
+            try {
+                const searchTerms = [];
+                const trimmedName = name.trim();
+                if (trimmedName) {
+                    searchTerms.push(trimmedName);
+                    const firstWord = trimmedName.split(/\s+/)[0];
+                    if (firstWord && firstWord.length > 1 && !searchTerms.includes(firstWord)) {
+                        searchTerms.push(firstWord);
+                    }
+                }
+
+                const suggestions = [];
+                const seenSuggestionIds = new Set();
+                for (const term of searchTerms) {
+                    const url = `https://${subdomain}.pipedrive.com/api/v1/organizations/search?term=${encodeURIComponent(term)}&fields=name&limit=5&api_token=${token}`;
+                    const res = await fetch(url);
+                    const data = await res.json();
+                    if (data.success && data.data && data.data.items) {
+                        data.data.items.forEach(entry => {
+                            const item = entry.item;
+                            if (!item || seenSuggestionIds.has(item.id)) return;
+                            seenSuggestionIds.add(item.id);
+                            suggestions.push(item);
+                        });
+                    }
+                }
+
+                organizationSuggestions[nameKey] = suggestions;
+                const div = document.createElement('div');
+                div.className = 'suggestion-block';
+                const title = document.createElement('strong');
+                title.textContent = `Suggestions for "${name}":`;
+                div.appendChild(title);
+                const select = document.createElement('select');
+                select.dataset.name = name;
+                select.dataset.key = nameKey;
+                select.dataset.recordType = 'organization';
+                const newOpt = document.createElement('option');
+                newOpt.value = 'new';
+                newOpt.textContent = '-- Create New --';
+                select.appendChild(newOpt);
+                suggestions.forEach(item => {
+                    const opt = document.createElement('option');
+                    opt.value = item.id;
+                    opt.textContent = `${item.name} (ID: ${item.id})`;
+                    select.appendChild(opt);
+                });
+                div.appendChild(document.createElement('br'));
+                div.appendChild(select);
+                const helpText = document.createElement('p');
+                helpText.className = 'org-selection-help';
+                helpText.textContent = 'Selecting "-- Create New --" creates a new organization for rows with this name using the mapped organization fields. Choosing an existing organization links those rows to that record and updates its mapped organization fields with the CSV values.';
+                div.appendChild(helpText);
+                suggestionContainer.appendChild(div);
+            } catch (err) {
+                console.error('Error fetching organization suggestions', err);
+            }
+        }
+    }
+
+    if (personNameCol) {
+        const uniquePersonNames = new Map();
+        csvData.forEach(row => {
+            const raw = row[personNameCol];
+            const key = normalizeNameKey(raw);
+            if (!key) return;
+            if (!uniquePersonNames.has(key)) {
+                uniquePersonNames.set(key, raw.trim());
+            }
+        });
+        if (uniquePersonNames.size > 0) {
+            const heading = document.createElement('h3');
+            heading.textContent = 'Person Suggestions';
+            personContainer.appendChild(heading);
+        }
+        for (const [nameKey, name] of uniquePersonNames.entries()) {
+            try {
+                const searchTerms = [];
+                const trimmedName = name.trim();
+                if (trimmedName) {
+                    searchTerms.push(trimmedName);
+                    const words = trimmedName.split(/\s+/).filter(Boolean);
+                    words.forEach(word => {
+                        if (word.length > 1 && !searchTerms.includes(word)) {
+                            searchTerms.push(word);
+                        }
+                    });
+                }
+                const suggestions = [];
+                const seenSuggestionIds = new Set();
+                for (const term of searchTerms) {
+                    const url = `https://${subdomain}.pipedrive.com/api/v1/persons/search?term=${encodeURIComponent(term)}&fields=name&limit=5&api_token=${token}`;
+                    const res = await fetch(url);
+                    const data = await res.json();
+                    if (data.success && data.data && data.data.items) {
+                        data.data.items.forEach(entry => {
+                            const item = entry.item;
+                            if (!item || seenSuggestionIds.has(item.id)) return;
+                            seenSuggestionIds.add(item.id);
+                            suggestions.push(item);
+                        });
+                    }
+                }
+                personSuggestions[nameKey] = suggestions;
+                const div = document.createElement('div');
+                div.className = 'suggestion-block';
+                const title = document.createElement('strong');
+                title.textContent = `Suggestions for "${name}":`;
+                div.appendChild(title);
+                const select = document.createElement('select');
+                select.dataset.name = name;
+                select.dataset.key = nameKey;
+                select.dataset.recordType = 'person';
+                const newOpt = document.createElement('option');
+                newOpt.value = 'new';
+                newOpt.textContent = '-- Create New --';
+                select.appendChild(newOpt);
+                suggestions.forEach(item => {
+                    const opt = document.createElement('option');
+                    opt.value = item.id;
+                    const orgName = item.organization ? (item.organization.name || item.organization) : null;
+                    opt.textContent = orgName ? `${item.name} (ID: ${item.id}, Org: ${orgName})` : `${item.name} (ID: ${item.id})`;
+                    select.appendChild(opt);
+                });
+                div.appendChild(document.createElement('br'));
+                div.appendChild(select);
+                const helpText = document.createElement('p');
+                helpText.className = 'org-selection-help';
+                helpText.textContent = 'Selecting "-- Create New --" creates a new person for rows with this name using the mapped person fields and links them to the mapped organization. Choosing an existing person links those rows to that record without changing the person\'s name while updating other mapped person fields.';
+                div.appendChild(helpText);
+                personContainer.appendChild(div);
+            } catch (err) {
+                console.error('Error fetching person suggestions', err);
+            }
         }
     }
 }
@@ -339,34 +570,37 @@ async function pushDataToPipedrive() {
     const token = document.getElementById('apitoken').value.trim();
     const pushStatus = document.getElementById('pushStatus');
     pushStatus.textContent = 'Processing...';
-    // Build a map from organization name to selected existing org ID
-    const selects = document.querySelectorAll('#orgSuggestionSection select');
+    const orgSelects = document.querySelectorAll('#orgSuggestionSection select[data-record-type="organization"]');
+    const personSelects = document.querySelectorAll('#personSuggestionSection select[data-record-type="person"]');
     const selectedOrgMap = {};
-    selects.forEach(sel => {
-        selectedOrgMap[sel.dataset.name] = sel.value;
+    const selectedPersonMap = {};
+    orgSelects.forEach(sel => {
+        selectedOrgMap[sel.dataset.key] = sel.value;
+    });
+    personSelects.forEach(sel => {
+        selectedPersonMap[sel.dataset.key] = sel.value;
     });
     for (const row of csvData) {
-        // Determine organization
         let orgId = null;
-        let orgPayload = {};
+        const orgPayload = {};
+        let orgNameValue = '';
         for (const col in columnMappings) {
             const mapVal = columnMappings[col];
             const value = row[col];
             if (!value) continue;
             if (mapVal === 'organization_name') {
-                // check if existing or new
-                const choice = selectedOrgMap[value];
+                orgNameValue = value.trim();
+                const choice = selectedOrgMap[normalizeNameKey(value)];
                 if (choice && choice !== 'new') {
                     orgId = choice;
-                } else {
-                    orgPayload.name = value;
+                } else if (orgNameValue) {
+                    orgPayload.name = orgNameValue;
                 }
             } else if (mapVal && mapVal.startsWith('orgField:')) {
                 const fieldKey = mapVal.split(':')[1];
                 orgPayload[fieldKey] = value;
             }
         }
-        // If orgPayload has fields and orgId is null -> create org
         if (!orgId && orgPayload.name) {
             const createOrgUrl = `https://${subdomain}.pipedrive.com/api/v1/organizations?api_token=${token}`;
             const res = await fetch(createOrgUrl, {
@@ -379,7 +613,6 @@ async function pushDataToPipedrive() {
                 orgId = data.data.id;
             }
         } else if (orgId && Object.keys(orgPayload).length > 0) {
-            // update org
             const updateOrgUrl = `https://${subdomain}.pipedrive.com/api/v1/organizations/${orgId}?api_token=${token}`;
             await fetch(updateOrgUrl, {
                 method: 'PUT',
@@ -387,35 +620,52 @@ async function pushDataToPipedrive() {
                 body: JSON.stringify(orgPayload)
             });
         }
-        // Handle person
-        let personPayload = {};
+
+        const personFieldValues = {};
+        let personNameValue = '';
         for (const col in columnMappings) {
             const mapVal = columnMappings[col];
             const value = row[col];
             if (!value) continue;
             if (mapVal === 'person_name') {
-                personPayload.name = value;
+                personNameValue = value.trim();
             } else if (mapVal && mapVal.startsWith('personField:')) {
                 const fieldKey = mapVal.split(':')[1];
-                personPayload[fieldKey] = value;
+                personFieldValues[fieldKey] = value;
             }
         }
-        if (orgId) personPayload.org_id = orgId;
         let personId = null;
-        if (personPayload.name) {
-            // Create person
-            const createPersonUrl = `https://${subdomain}.pipedrive.com/api/v1/persons?api_token=${token}`;
-            const res = await fetch(createPersonUrl, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(personPayload)
-            });
-            const data = await res.json();
-            if (data.success) {
-                personId = data.data.id;
+        if (personNameValue) {
+            const personChoice = selectedPersonMap[normalizeNameKey(personNameValue)];
+            if (personChoice && personChoice !== 'new') {
+                personId = personChoice;
+                const updatePayload = { ...personFieldValues };
+                if (orgId) updatePayload.org_id = orgId;
+                if (Object.keys(updatePayload).length > 0) {
+                    const updatePersonUrl = `https://${subdomain}.pipedrive.com/api/v1/persons/${personId}?api_token=${token}`;
+                    await fetch(updatePersonUrl, {
+                        method: 'PUT',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(updatePayload)
+                    });
+                }
+            } else {
+                const createPayload = { ...personFieldValues };
+                createPayload.name = personNameValue;
+                if (orgId) createPayload.org_id = orgId;
+                const createPersonUrl = `https://${subdomain}.pipedrive.com/api/v1/persons?api_token=${token}`;
+                const res = await fetch(createPersonUrl, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(createPayload)
+                });
+                const data = await res.json();
+                if (data.success) {
+                    personId = data.data.id;
+                }
             }
         }
-        // Handle note
+
         const noteCol = Object.keys(columnMappings).find(col => columnMappings[col] === 'note');
         if (noteCol && row[noteCol]) {
             const notePayload = {
@@ -441,8 +691,85 @@ document.getElementById('csvFileInput').addEventListener('change', function(e) {
         parseCSV(file);
     }
 });
-document.getElementById('searchOrgBtn').addEventListener('click', searchExistingOrganizations);
+document.getElementById('toggleFieldsBtn').addEventListener('click', toggleFieldsSection);
+document.getElementById('searchRecordsBtn').addEventListener('click', searchExistingRecords);
 document.getElementById('pushDataBtn').addEventListener('click', pushDataToPipedrive);
+
+async function createNewField(entityType, name, fieldType) {
+    const subdomain = document.getElementById('subdomain').value.trim();
+    const token = document.getElementById('apitoken').value.trim();
+    if (!subdomain || !token) {
+        alert('Please enter subdomain and API token before adding new fields.');
+        throw new Error('Missing credentials');
+    }
+    const endpoint = entityType === 'organization' ? 'organizationFields' : 'personFields';
+    const url = `https://${subdomain}.pipedrive.com/api/v1/${endpoint}?api_token=${token}`;
+    const payload = {
+        name,
+        field_type: fieldType,
+        add_visible_flag: false
+    };
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    });
+    const data = await res.json();
+    if (!data.success) {
+        const message = (data && data.error) ? data.error : 'Failed to create field.';
+        throw new Error(message);
+    }
+    return data.data;
+}
+
+async function handleAddNewField(select, columnName) {
+    const previousValue = select.dataset.previousValue || '';
+    const entityInput = prompt('Add field to which record type? Enter "organization" or "person".');
+    if (!entityInput) {
+        select.value = previousValue;
+        return;
+    }
+    const normalizedEntity = entityInput.trim().toLowerCase();
+    if (normalizedEntity !== 'organization' && normalizedEntity !== 'person') {
+        alert('Please enter "organization" or "person".');
+        select.value = previousValue;
+        return;
+    }
+    const nameInput = prompt('Enter a name for the new field:');
+    if (!nameInput || !nameInput.trim()) {
+        alert('Field name is required.');
+        select.value = previousValue;
+        return;
+    }
+    const typeInput = prompt('Enter the field type (e.g., text, varchar, int, double, date, address, phone).');
+    if (!typeInput || !typeInput.trim()) {
+        alert('Field type is required.');
+        select.value = previousValue;
+        return;
+    }
+    try {
+        const newField = await createNewField(normalizedEntity, nameInput.trim(), typeInput.trim());
+        const success = await fetchFields();
+        if (!success) {
+            select.value = previousValue;
+            return;
+        }
+        const mappingValue = `${normalizedEntity === 'organization' ? 'orgField' : 'personField'}:${newField.key}`;
+        columnMappings[columnName] = mappingValue;
+        const optionExists = Array.from(select.options).some(opt => opt.value === mappingValue);
+        if (optionExists) {
+            select.value = mappingValue;
+        }
+        select.dataset.previousValue = select.value;
+        alert(`Field "${nameInput.trim()}" created successfully.`);
+    } catch (err) {
+        console.error('Error creating new field', err);
+        if (err.message && err.message !== 'Missing credentials') {
+            alert(err.message);
+        }
+        select.value = previousValue;
+    }
+}
 
 // Function to handle tab switching for fields section
 function openTab(evt, tabName) {


### PR DESCRIPTION
## Summary
- query organization suggestions with both the full CSV value and its leading word to surface close matches
- de-duplicate results so the dropdown only shows unique organization suggestions
- add combined organization & person suggestion search with per-record selects, descriptive help, and normalization to reuse choices during import
- include person suggestion metadata (full name, ID, org) and ensure existing selections skip renaming while updating other mapped fields

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e4ddd5e07483309a0205991f0013fd